### PR TITLE
Remove keycertsign and crlsign from the sub

### DIFF
--- a/nitroCA/config/sign_subordinate_csr.ini
+++ b/nitroCA/config/sign_subordinate_csr.ini
@@ -34,4 +34,4 @@ emailAddress            = optional
 subjectKeyIdentifier = hash
 authorityKeyIdentifier = keyid:always,issuer
 basicConstraints = critical, CA:true, pathlen:0
-keyUsage = critical, digitalSignature, cRLSign, keyCertSign
+keyUsage = critical, digitalSignature


### PR DESCRIPTION
Removing extra (unintended) usage. 

Since pathlen is 0, the certificate will not be used for certificate signing and revocation signing. Thus cleaning.