### PR TITLE
Explicitly use Jammy base docker image

### DIFF
--- a/yubikey/Dockerfile
+++ b/yubikey/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ubuntu:latest
+FROM ubuntu:jammy
 
 # Install dependencies
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \


### PR DESCRIPTION
To avoid surprise changes in what base image gets used when there's a new Ubuntu LTS release.